### PR TITLE
Alarmmeter : disable rtc setup during suspend operation

### DIFF
--- a/kernel/time/alarmtimer.c
+++ b/kernel/time/alarmtimer.c
@@ -923,7 +923,9 @@ static const struct dev_pm_ops alarmtimer_pm_ops = {
 static struct platform_driver alarmtimer_driver = {
 	.driver = {
 		.name = "alarmtimer",
+#if 0
 		.pm = &alarmtimer_pm_ops,
+#endif
 	}
 };
 


### PR DESCRIPTION
Suspend fails when we do force suspend.
This patch is to disable rtc setup for alarmmeter during suspend operation.

Tests done: tested on suspend/resume test case

Tracked-On: OAM-128614